### PR TITLE
Implements destroy logic

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Validate config
         run: |
+          echo "Github sha: ${{ github.sha }}"
+          echo "Github ref: ${{ github.ref }}"
           if [ -z "${NAMESPACE}" ]; then
             echo "The NAMESPACE secret has not been set within the Git repo"
             exit 1
@@ -49,33 +51,34 @@ jobs:
       - name: Setup ${{ matrix.platform }}
         run: |
           ls -lA
-          mkdir -p /tmp/workspace/${{ matrix.platform }}
-          cp -R ./test/setup/stages/* /tmp/workspace/${{ matrix.platform }}
-          cp -R ./test/setup/scripts/* /tmp/workspace/${{ matrix.platform }}
+          mkdir -p /tmp/workspace/module
+          cp -R ./test/setup/stages/* /tmp/workspace
+          cp -R ./test/setup/scripts/* /tmp/workspace
+          cp -R . /tmp/workspace/module
 
       # Deploy
       - name: Deploy ${{ matrix.platform }}
         run: |
-          cd /tmp/workspace/${{ matrix.platform }}
+          cd /tmp/workspace
           ./apply.sh
 
       # Test deploy
       - name: Validate deploy ${{ matrix.platform }}
         run: |
-          cd /tmp/workspace/${{ matrix.platform }}
+          cd /tmp/workspace
           ./validate-deploy.sh ${{ matrix.platform }} ${{ env.TF_VAR_tools_namespace }}
 
       # Destroy
       - name: Destroy ${{ matrix.platform }}
         run: |
-          cd /tmp/workspace/${{ matrix.platform }}
+          cd /tmp/workspace
           ./destroy.sh
 
       # Test destroy
       - name: Validate destroy ${{ matrix.platform }}
         run: |
-          cd /tmp/workspace/${{ matrix.platform }}
-          ./capture-cluster-state.sh ${{ matrix.platform }} ${{ env.NAMESPACE }} $PWD/cluster-state/after/${{ env.NAMESPACE }}.out
+          cd /tmp/workspace
+          ./capture-cluster-state.sh ${{ matrix.platform }} $PWD/cluster-state/before $PWD/cluster-state/after
           if diff -q $PWD/cluster-state/before $PWD/cluster-state/after 1> /dev/null; then
             echo "Destroy completed successfully"
           else

--- a/scripts/destroy-instance.sh
+++ b/scripts/destroy-instance.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+NAMESPACE="$1"
+NAME="$2"
+
+if kubectl get -n "${NAMESPACE}" jaeger.jaegertracing.io "${NAME}" 1> /dev/null 2> /dev/null; then
+  echo "Deleting jaeger instance: ${NAMESPACE}/${NAME}"
+  kubectl delete -n "${NAMESPACE}" jaeger.jaegertracing.io "${NAME}" --wait
+else
+  echo "Unable to find jaeger instance: ${NAMESPACE}/${NAME}"
+fi
+

--- a/scripts/destroy-subscription.sh
+++ b/scripts/destroy-subscription.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+NAMESPACE="$1"
+
+if kubectl get -n "${NAMESPACE}" subscription jaeger 1> /dev/null 2> /dev/null; then
+  echo "Deleting Jaeger operator subscription: ${NAMESPACE}"
+  kubectl delete -n "${NAMESPACE}" subscription jaeger
+else
+  echo "Unable to find subscription for Jaeger operator in ${NAMESPACE}"
+fi

--- a/test/setup/scripts/capture-cluster-state.sh
+++ b/test/setup/scripts/capture-cluster-state.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
 PLATFORM="$1"
-NAMESPACE="$2"
-OUTFILE="$3"
+INFILE_DIR="$2"
+OUTFILE_DIR="$3"
 
-OUTFILE_DIR=$(dirname "${OUTFILE}")
 mkdir -p "${OUTFILE_DIR}"
 
 resources="deployment,statefulset,service,ingress,configmap,secret"
@@ -16,21 +15,26 @@ if [[ "$PLATFORM" == "ocp3" ]] || [[ "$PLATFORM" == "ocp4" ]]; then
   fi
 fi
 
-echo "Checking on namespace - ${NAMESPACE}"
+ls "${INFILE_DIR}" | while read infile; do
+  NAMESPACE="${infile//.out/}"
+  OUTFILE="${OUTFILE_DIR}/${infile}"
 
-if kubectl get namespace "${NAMESPACE}" 1> /dev/null 2> /dev/null; then
-  echo "Listing resources in namespace - ${resources}"
+  echo "Checking on namespace - ${NAMESPACE}"
 
-  kubectl get -n "${NAMESPACE}" "${resources}" -o jsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.kind}{"/"}{.metadata.name}{"\n"}{end}' | \
-    tr '[:upper:]' '[:lower:]' > "${OUTFILE}"
-else
-  echo "Namespace does not exist - ${NAMESPACE}"
-  touch "${OUTFILE}"
-fi
+  if kubectl get namespace "${NAMESPACE}" 1> /dev/null 2> /dev/null; then
+    echo "Listing resources in namespace - ${resources}"
 
-if kubectl get subscription --all-namespaces 1> /dev/null 2> /dev/null; then
-  kubectl get --all-namespaces subscription -o jsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.kind}{"/"}{.metadata.name}{"\n"}{end}' 2> /dev/null | \
-    tr '[:upper:]' '[:lower:]' >> "${OUTFILE}"
-fi
+    kubectl get -n "${NAMESPACE}" "${resources}" -o jsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.kind}{"/"}{.metadata.name}{"\n"}{end}' | \
+      tr '[:upper:]' '[:lower:]' > "${OUTFILE}"
+  else
+    echo "Namespace does not exist - ${NAMESPACE}"
+    touch "${OUTFILE}"
+  fi
 
-cat "${OUTFILE}"
+  if kubectl get subscription -n "${NAMESPACE}" 1> /dev/null 2> /dev/null; then
+    kubectl get -n "${NAMESPACE}" subscription -o jsonpath='{range .items[*]}{.metadata.namespace}{"/"}{.kind}{"/"}{.metadata.name}{"\n"}{end}' 2> /dev/null | \
+      tr '[:upper:]' '[:lower:]' >> "${OUTFILE}"
+  fi
+
+  cat "${OUTFILE}"
+done

--- a/test/setup/stages/stage1b-capture-state.tf
+++ b/test/setup/stages/stage1b-capture-state.tf
@@ -1,8 +1,26 @@
-module "dev_capture_state" {
+module "dev_capture_tools_state" {
   source = "github.com/ibm-garage-cloud/terraform-k8s-capture-state"
 
   cluster_type             = module.dev_cluster.type_code
   cluster_config_file_path = module.dev_cluster.config_file_path
   namespace                = module.dev_tools_namespace.name
+  output_path              = "${path.cwd}/cluster-state/before"
+}
+
+module "dev_capture_olm_state" {
+  source = "github.com/ibm-garage-cloud/terraform-k8s-capture-state"
+
+  cluster_type             = module.dev_cluster.type_code
+  cluster_config_file_path = module.dev_cluster.config_file_path
+  namespace                = module.dev_software_olm.olm_namespace
+  output_path              = "${path.cwd}/cluster-state/before"
+}
+
+module "dev_capture_operator_state" {
+  source = "github.com/ibm-garage-cloud/terraform-k8s-capture-state"
+
+  cluster_type             = module.dev_cluster.type_code
+  cluster_config_file_path = module.dev_cluster.config_file_path
+  namespace                = module.dev_software_olm.target_namespace
   output_path              = "${path.cwd}/cluster-state/before"
 }

--- a/test/setup/stages/stage2-jaeger.tf
+++ b/test/setup/stages/stage2-jaeger.tf
@@ -1,11 +1,11 @@
 module "dev_tools_jaeger" {
-  source = "github.com/ibm-garage-cloud/terraform-tools-jaeger.git"
+  source = "./module"
 
   cluster_config_file = module.dev_cluster.config_file_path
   cluster_type        = module.dev_cluster.type_code
   ingress_subdomain   = module.dev_cluster.ingress_hostname
-  olm_namespace       = module.dev_software_olm.olm_namespace
-  operator_namespace  = module.dev_software_olm.target_namespace
-  app_namespace       = module.dev_capture_state.namespace
+  olm_namespace       = module.dev_capture_olm_state.namespace
+  operator_namespace  = module.dev_capture_operator_state.namespace
+  app_namespace       = module.dev_capture_tools_state.namespace
   name                = "jaeger"
 }


### PR DESCRIPTION
- Adds kubeconfig to triggers in main.tf
- Print out github.sha and github.ref in pipeline
- Delete jaeger instance from provided namespace
- Adds logic to destroy subscription
- For OLM install, capture state of olm namespaces and tools namespace
- In capture-cluster-state.sh read files in before/ folder to get list of namespaces to check

Updates build to support PR build

- Simplifies workspace structure and puts it in folder relative to working directory
- Updates module under test to use local filesystem for module definition
